### PR TITLE
fix missing type

### DIFF
--- a/app_worker/worker/core/downloader.py
+++ b/app_worker/worker/core/downloader.py
@@ -15,7 +15,7 @@ from worker.core.exceptions import MediaDownloaderError
 from ytdl_opts.per_host._base import AbstractHostConfig
 
 try:
-    from ytdl_opts.user import FINAL_THUMBNAIL_FORMAT
+    from ytdl_opts.user import FINAL_AUDIO_FORMAT, FINAL_THUMBNAIL_FORMAT
 except ImportError:
     from ytdl_opts.default import FINAL_AUDIO_FORMAT, FINAL_THUMBNAIL_FORMAT
 


### PR DESCRIPTION
fix missing typing when user config of downloader is enabled

```
yt_worker    | Traceback (most recent call last):
yt_worker    |   File "/app/main.py", line 5, in <module>
yt_worker    |     from worker.core.launcher import WorkerLauncher
yt_worker    |   File "/app/worker/core/launcher.py", line 12, in <module>
yt_worker    |     from worker.core.callbacks import rmq_callbacks as cb
yt_worker    |   File "/app/worker/core/callbacks.py", line 6, in <module>
yt_worker    |     from worker.core.payload_handler import PayloadHandler
yt_worker    |   File "/app/worker/core/payload_handler.py", line 13, in <module>
yt_worker    |     from worker.core.media_service import MediaService
yt_worker    |   File "/app/worker/core/media_service.py", line 21, in <module>
yt_worker    |     from worker.core.downloader import MediaDownloader
yt_worker    |   File "/app/worker/core/downloader.py", line 23, in <module>
yt_worker    |     class MediaDownloader:
yt_worker    |   File "/app/worker/core/downloader.py", line 29, in MediaDownloader
yt_worker    |     FINAL_AUDIO_FORMAT: 'audio',
yt_worker    |     ^^^^^^^^^^^^^^^^^^
yt_worker    | NameError: name 'FINAL_AUDIO_FORMAT' is not defined. Did you mean: 'FINAL_THUMBNAIL_FORMAT'?

```